### PR TITLE
Changed .error to .fail such that passport doesn't spit out the error…

### DIFF
--- a/lib/Strategy.js
+++ b/lib/Strategy.js
@@ -62,7 +62,7 @@ GooglePlusTokenStrategy.prototype.authenticate = function (req, options) {
   }
 
   self._loadUserProfile(accessToken, function (error, profile) {
-    if (error) return self.error(error);
+    if (error) return self.fail(error);
 
     function verified(error, user, info) {
       if (error) return self.error(error);


### PR DESCRIPTION
…, but instead it just gives a 401 in case the access_token is incorrect.